### PR TITLE
feat(ipc): support call reboot with restful api

### DIFF
--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -19,6 +19,7 @@ type Context struct {
 	IsAdmin           bool
 	RestfulEndpoint   string
 	EventSocketPath   string
+	CanReboot         bool
 }
 
 func Setup() (*Context, error) {
@@ -41,6 +42,7 @@ func (c *Context) basic() error {
 	c.Name = name
 	c.RestfulEndpoint = `\\.\pipe\ovm-` + c.Name
 	c.EventSocketPath = `\\.\pipe\` + eventNpipeName
+	c.CanReboot = false
 	return nil
 }
 

--- a/pkg/wsl/install.go
+++ b/pkg/wsl/install.go
@@ -45,6 +45,7 @@ func Install(opt *cli.Context, log *logger.Context) error {
 			}
 
 			log.Info("Admin process already successfully executed and exited")
+			opt.CanReboot = true
 			return nil
 		}
 


### PR DESCRIPTION
#### Test

```js
import url from "node:url";
import http from 'node:http';

const reboot = () => {
    const h = http.request({
        socketPath: "//./pipe/ovm-test",
        path: "/reboot",
        method: "POST",
    }, (response) => {
        response.setEncoding("utf8");
        let body = "";
        response.on("data", (chunk) => {
            body += chunk;
        });

        response.on("end", () =>{
            const { statusCode } = response;

            if (!statusCode || statusCode >= 400) {
                console.error("Error:", body);
            } else {
                console.log("Success:", body);
            }
        })
    }).on("error", err => {
        console.error("request Error:", err.message);
    });

    h.write(JSON.stringify({
        runOnce: "notepad.exe",
    }));

    h.end();
}

const server = http.createServer((req, res) => {
    if (!req.url) {
        console.log("No URL");
        res.writeHead(400);
        res.end();
        return;
    }

    const parsedUrl = url.parse(req.url);
    if (parsedUrl.pathname === "/notify") {
        console.log("notify");
        console.log(req.url);
        res.writeHead(200);
        res.end();

        if (req.url.indexOf("Reboot") !== -1) {
            console.log("Rebooting");
            setTimeout(() => {
                reboot();
            } , 1000 * 10)
        }
    } else {
        console.log("Not found");
        res.writeHead(404);
        res.end();
    }
});

server.listen("//./pipe/ovm-test2").on("error", (err) => {
    console.log("Error:", err.message);
});
```

```cli
.\ovm-amd64.exe --name test --log-path=.\test --event-npipe-name ovm-test2
```