### PR TITLE
feat(sys): support check system version

### DIFF
--- a/cmd/ovm/main.go
+++ b/cmd/ovm/main.go
@@ -69,8 +69,13 @@ func main() {
 
 	event.Setup(log, opt.EventSocketPath)
 
-	// WSL Install / Check / Update
+	// WSL Check / Install / Update
 	{
+		if !sys.SupportWSL2(log) {
+			log.Error("WSL2 is not supported on this system, need Windows 10 version 19043 or higher")
+			exit(1)
+		}
+
 		if err := wsl.Install(opt, log); err != nil {
 			if wsl.IsNeedReboot(err) {
 				log.Info("Need reboot system")

--- a/pkg/winapi/sys/version.go
+++ b/pkg/winapi/sys/version.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-License-Identifier: MPL-2.0
+
+package sys
+
+import (
+	"github.com/oomol-lab/ovm-win/pkg/logger"
+	"golang.org/x/sys/windows"
+)
+
+// 19043 == 21H1
+// Although Microsoft claims that 19041 supports WSL2, it was actually supported in subsequent updates,
+// not from the beginning. Version 19043 supports WSL2 from the start. For convenience, 19043 is used here.
+const minBuildNumber uint32 = 19043
+
+func SupportWSL2(log *logger.Context) bool {
+	v := windows.RtlGetVersion()
+
+	log.Infof("Current system build number is %d", v.BuildNumber)
+
+	return v.BuildNumber >= minBuildNumber
+}


### PR DESCRIPTION
System build number must >= 19043

Although Microsoft claims that 19041 supports WSL2, it was actually supported in subsequent updates, not from the beginning. Version 19043 supports WSL2 from the start. For convenience, 19043 is used here.