### PR TITLE
feat(update): support version manager

### DIFF
--- a/cmd/ovm/main.go
+++ b/cmd/ovm/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oomol-lab/ovm-win/pkg/ipc/event"
 	"github.com/oomol-lab/ovm-win/pkg/ipc/restful"
 	"github.com/oomol-lab/ovm-win/pkg/logger"
+	"github.com/oomol-lab/ovm-win/pkg/update"
 	"github.com/oomol-lab/ovm-win/pkg/winapi/sys"
 	"github.com/oomol-lab/ovm-win/pkg/wsl"
 	"golang.org/x/sync/errgroup"
@@ -105,6 +106,12 @@ func main() {
 		} else {
 			log.Info("WSL2 is up to date")
 		}
+	}
+
+	if err := update.New(opt).CheckAndReplace(); err != nil {
+		log.Errorf("Failed to update: %v", err)
+		cancel()
+		exit(1)
 	}
 
 	go func() {

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -11,12 +11,18 @@ import (
 var (
 	name           string
 	logPath        string
+	imageDir       string
+	rootfsPath     string
+	versions       string
 	eventNpipeName string
 )
 
 func parse() error {
 	flag.StringVar(&name, "name", "", "Name of the virtual machine")
 	flag.StringVar(&logPath, "log-path", "", "Path to the log file")
+	flag.StringVar(&imageDir, "image-dir", "", "Store disk images")
+	flag.StringVar(&rootfsPath, "rootfs-path", "", "Path to rootfs image")
+	flag.StringVar(&versions, "versions", "", "Set versions")
 	flag.StringVar(&eventNpipeName, "event-npipe-name", "", "HTTP server established in the named pipe (such as the foo in //./pipe/foo) must implement the GET /notify?event=&message= route")
 
 	flag.Parse()
@@ -31,6 +37,18 @@ func validate() error {
 
 	if logPath == "" {
 		return fmt.Errorf("log-path is required in cli")
+	}
+
+	if imageDir == "" {
+		return fmt.Errorf("images-path is required in cli")
+	}
+
+	if rootfsPath == "" {
+		return fmt.Errorf("rootfs-path is required in cli")
+	}
+
+	if versions == "" {
+		return fmt.Errorf("versions is required in cli")
 	}
 
 	if eventNpipeName == "" {

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/oomol-lab/ovm-win/pkg/types"
 	"github.com/oomol-lab/ovm-win/pkg/winapi/sys"
 	"golang.org/x/sync/errgroup"
 )
@@ -15,6 +17,8 @@ import (
 type Context struct {
 	Name              string
 	LogPath           string
+	ImageDir          string
+	Version           types.Version
 	IsElevatedProcess bool
 	IsAdmin           bool
 	RestfulEndpoint   string
@@ -24,7 +28,6 @@ type Context struct {
 
 func Setup() (*Context, error) {
 	if err := parse(); err != nil {
-		fmt.Printf("validate flags error: %v\n", err)
 		return nil, fmt.Errorf("validate flags error: %v\n", err)
 	}
 
@@ -34,6 +37,7 @@ func Setup() (*Context, error) {
 	g.Go(ctx.basic)
 	g.Go(ctx.logPath)
 	g.Go(ctx.process)
+	g.Go(ctx.update)
 
 	return ctx, g.Wait()
 }
@@ -63,5 +67,46 @@ func (c *Context) logPath() error {
 func (c *Context) process() error {
 	c.IsAdmin = sys.IsAdmin()
 
+	return nil
+}
+
+func (c *Context) update() error {
+	p, err := filepath.Abs(imageDir)
+	if err != nil {
+		return fmt.Errorf("failed to get imageDir absolute path from %s: %v", imageDir, err)
+	}
+	if err := os.MkdirAll(p, 0755); err != nil {
+		return fmt.Errorf("failed to create imageDir folder %s: %v", p, err)
+	}
+	c.ImageDir = p
+
+	version := types.Version{}
+	s := strings.Split(versions, ",")
+
+	for _, val := range s {
+		item := strings.Split(strings.TrimSpace(val), "=")
+		if len(item) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(item[0])
+
+		switch key {
+		case types.VersionRootFS:
+			version.RootFS = strings.TrimSpace(item[1])
+		case types.VersionData:
+			version.Data = strings.TrimSpace(item[1])
+		}
+	}
+
+	if version.RootFS == "" {
+		return fmt.Errorf("need %s in versions", types.VersionRootFS)
+	}
+
+	if version.Data == "" {
+		return fmt.Errorf("need %s in versions", types.VersionData)
+	}
+
+	c.Version = version
 	return nil
 }

--- a/pkg/types/constant.go
+++ b/pkg/types/constant.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+type VersionKey = string
+
+const (
+	VersionRootFS VersionKey = "rootfs"
+	VersionData   VersionKey = "data"
+)
+
+type Version struct {
+	RootFS string `json:"rootfs"`
+	Data   string `json:"data"`
+}

--- a/pkg/update/handler.go
+++ b/pkg/update/handler.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-License-Identifier: MPL-2.0
+
+package update
+
+import "fmt"
+
+// TODO
+func updateRootfs() error {
+	fmt.Println("updateRootfs")
+	return nil
+}
+
+// TODO
+func updateDate() error {
+	fmt.Println("updateDate")
+	return nil
+}

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2024 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-License-Identifier: MPL-2.0
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/oomol-lab/ovm-win/pkg/cli"
+	"github.com/oomol-lab/ovm-win/pkg/types"
+	"golang.org/x/sync/errgroup"
+)
+
+type Updater interface {
+	CheckAndReplace() error
+}
+
+type context struct {
+	types.Version
+
+	opt      *cli.Context
+	jsonPath string
+}
+
+func New(opt *cli.Context) (updater Updater) {
+	return &context{
+		Version:  opt.Version,
+		opt:      opt,
+		jsonPath: filepath.Join(opt.ImageDir, "versions.json"),
+	}
+}
+
+func (c *context) save() error {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("failed to marshal versions: %w", err)
+	}
+
+	if err := os.WriteFile(c.jsonPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write versions to %s: %w", c.jsonPath, err)
+	}
+
+	return nil
+}
+
+func (c *context) needUpdate() (result []types.VersionKey) {
+	jsonVersion := &context{}
+
+	data, err := os.ReadFile(c.jsonPath)
+	if err != nil {
+		return []types.VersionKey{types.VersionRootFS, types.VersionData}
+	}
+
+	if err := json.Unmarshal(data, jsonVersion); err != nil {
+		_ = os.RemoveAll(c.jsonPath)
+		return []types.VersionKey{types.VersionRootFS, types.VersionData}
+	}
+
+	if jsonVersion.RootFS != c.RootFS {
+		result = append(result, types.VersionRootFS)
+	}
+
+	if jsonVersion.Data != c.Data {
+		result = append(result, types.VersionData)
+	}
+
+	return
+}
+
+func (c *context) CheckAndReplace() error {
+	list := c.needUpdate()
+	if len(list) == 0 {
+		return nil
+	}
+
+	var g errgroup.Group
+
+	for _, item := range list {
+		switch item {
+		case types.VersionRootFS:
+			g.Go(updateRootfs)
+		case types.VersionData:
+			g.Go(updateDate)
+		}
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	if err := c.save(); err != nil {
+		return fmt.Errorf("failed to save versions: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR is not complete. It only implements version management, so that when the rootfs/data version changes, the ovm can be aware of it.

```bash
.\ovm-amd64.exe --name test --log-path=.\test --event-npipe-name ovm-test2 --image-dir=./image --rootfs-path=./rootfs --versions="rootfs=1.0.0,data=1.0.0"
```