### PR TITLE
fix(prepare): virtualization detection is incorrect

### DIFF
--- a/pkg/cli/prepare.go
+++ b/pkg/cli/prepare.go
@@ -95,6 +95,7 @@ func (c *PrepareContext) Start() error {
 	case <-ctx.Done():
 		return fmt.Errorf("app unexpectedly exit, because the context is done, ctx err: %v", context.Cause(ctx))
 	case <-channel.ReceiveWSLEnvReady():
+		wsl.CheckBIOS(&c.PrepareOpt)
 		return nil
 	}
 }

--- a/pkg/util/misc.go
+++ b/pkg/util/misc.go
@@ -3,7 +3,15 @@
 
 package util
 
-import "hash/fnv"
+import (
+	"hash/fnv"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 const initSize uint64 = 301 * 1024 * 1024 * 1024
 
@@ -21,4 +29,14 @@ func generateNumberFNV(s string) uint32 {
 	hash := fnv.New32a()
 	_, _ = hash.Write([]byte(s))
 	return hash.Sum32()%50000 + 1
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+func RandomString(l int) string {
+	b := make([]rune, l)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
Some systems have virtualization enabled, but both VF and SLAT return false, so we cannot determine it solely based on them.