### PR TITLE
fix(wsl): incorrect detection result for feature enabled status

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -43,6 +43,9 @@ words:
   - npipe
   - Npipe
   - sddl
+
+  # pkg/wsl
+  - enablevirtualization
 dictionaries:
   - companies
   - softwareTerms

--- a/pkg/util/exec.go
+++ b/pkg/util/exec.go
@@ -1,12 +1,10 @@
-// SPDX-FileCopyrightText: 2024 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-FileCopyrightText: 2024-2025 OOMOL, Inc. <https://www.oomol.com>
 // SPDX-License-Identifier: MPL-2.0
 
 package util
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -38,21 +36,6 @@ func SilentCmdContext(ctx context.Context, command string, args ...string) *exec
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: flagsCreateNoWindow}
 	return cmd
-}
-
-func Exec(log *logger.Context, command string, args ...string) (string, error) {
-	cmd := SilentCmd(command, args...)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	log.Infof("Running command: %s %s", command, strings.Join(args, " "))
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("`%v %v` failed: %v %v (%v)", command, strings.Join(args, " "), stderr.String(), stdout.String(), err)
-	}
-
-	return stdout.String(), nil
 }
 
 func EscapeArg(args []string) string {

--- a/pkg/wsl/distro.go
+++ b/pkg/wsl/distro.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024-2025 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-License-Identifier: MPL-2.0
+
 package wsl
 
 import (
@@ -21,15 +24,6 @@ import (
 
 var ErrDistroNotExist = errors.New("distro does not exist")
 var ErrDistroNotRunning = errors.New("distro is not running")
-
-// Shutdown the wsl2 entirely
-func Shutdown(log *logger.Context) error {
-	if _, err := wslExec(log, "--shutdown"); err != nil {
-		return fmt.Errorf("could not shutdown WSL: %w", err)
-	}
-
-	return nil
-}
 
 func Terminate(log *logger.Context, distroName string) error {
 	if _, err := wslExec(log, "--terminate", distroName); err != nil {
@@ -250,6 +244,8 @@ func getAllWSLDistros(log *logger.Context, running bool) (map[string]struct{}, e
 	args := []string{"--list", "--quiet"}
 	if running {
 		args = append(args, "--running")
+	} else {
+		args = append(args, "--all")
 	}
 
 	out, err := wslExec(log, args...)
@@ -261,7 +257,7 @@ func getAllWSLDistros(log *logger.Context, running bool) (map[string]struct{}, e
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 	scanner.Split(bufio.ScanLines)
 
-	// `wsl --list --quiet` output:
+	// `wsl --list --quiet --all` output:
 	//
 	//	Ubuntu
 	//	Debian


### PR DESCRIPTION
In the new version, the behavior of `wsl --set-default-version` has been changed. In previous versions, if features were not enabled, it would report an error, but the latest version does not. We need to check in other ways.