### PR TITLE
fix(wsl): check wsl status is incorrect

### DIFF
--- a/pkg/wsl/check.go
+++ b/pkg/wsl/check.go
@@ -20,11 +20,11 @@ import (
 )
 
 func Check(ctx context.Context, opt *types.InitOpt) {
-	if ok := checkFeature(ctx, opt); !ok {
+	if ok := checkVersion(ctx, opt); !ok {
 		return
 	}
 
-	if ok := checkVersion(ctx, opt); !ok {
+	if ok := checkFeature(ctx, opt); !ok {
 		return
 	}
 


### PR DESCRIPTION
When there is no WSL installed on the computer, executing `wsl --version` or wsl `--set-default-version` will directly start downloading WSL, which is inconsistent with the expected behavior and will lead our code logic to think that Windows features are not enabled.

Therefore, we placed the WSL update logic at the very beginning to avoid this issue.