### PR TITLE
fix(ovmd): startup failure with legacy version present

### DIFF
--- a/pkg/wsl/distro.go
+++ b/pkg/wsl/distro.go
@@ -211,13 +211,16 @@ func launchOVMD(ctx context.Context, opt *types.RunOpt) error {
 		return fmt.Errorf("could not create vm logger: %w", err)
 	}
 
+	// Backward compatibility
+	oldDataSector := util.DataSize(opt.Name+opt.ImageDir) / 512
 	dataSector := util.DataSize(opt.Name) / 512
-	// See: https://github.com/oomol-lab/ovm-builder/blob/main/scripts/ovmd
+
+	// See: https://github.com/oomol-lab/ovm-builder/blob/main/layers/wsl2_amd64/opt/ovmd
 	cmd := util.SilentCmdContext(ctx, Find(),
 		"-d", opt.DistroName,
 		"/opt/ovmd",
 		"-p", fmt.Sprintf("%d", opt.PodmanPort),
-		"-s", fmt.Sprintf("%d", dataSector),
+		"-s", fmt.Sprintf("%d,%d", dataSector, oldDataSector),
 	)
 	cmd.Env = []string{"WSL_UTF8=1"}
 


### PR DESCRIPTION
This issue is caused by #94. If the user's computer has a previous version of the OVM installed, there will be compatibility issues when using the latest OVM, resulting in the data size being inconsistent, which prevents ovmd from starting.

Current changes depend on support from https://github.com/oomol-lab/ovm-builder.


https://github.com/oomol-lab/ovm-builder/pull/59