### PR TITLE
chore(wsl): update wsl min version to 2.3.24

### DIFF
--- a/pkg/wsl/check.go
+++ b/pkg/wsl/check.go
@@ -310,7 +310,7 @@ func wslVersion(log *logger.Context) (string, error) {
 	return strings.TrimSpace(wslLine[offset+1:]), nil
 }
 
-const minVersion = "2.1.5"
+const minVersion = "2.3.24"
 
 func shouldUpdateWSL(log *logger.Context) bool {
 	if isInstalled := isInstalled(log); !isInstalled {


### PR DESCRIPTION
In versions before WSL@2.1.0, there were compatibility issues with Winsock, which could lead to WSL not functioning properly. For more information, see: https://github.com/microsoft/WSL/issues/4177

In versions before WSL@2.3.24, there was a chance of failure when creating a VM due to network issues.