### PR TITLE
fix(port): no error is reported even if the port is occupied

### DIFF
--- a/pkg/util/port.go
+++ b/pkg/util/port.go
@@ -10,7 +10,7 @@ import (
 )
 
 func portOccupied(port int) error {
-	ln, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+	ln, err := net.Listen("tcp4", ":"+strconv.Itoa(port))
 	if err != nil {
 		return fmt.Errorf("port %d is occupied, %v", port, err)
 	}


### PR DESCRIPTION
Using `tcp` makes the Listen address obscure and dependent on the behavior of the operating system(ipv6 has higher priority than ipv4). 

Using `tcp4` ensures that only the ipv4 network stack is listened to, not both ipv6 and ipv4.

Related issue https://github.com/oomol-lab/ovm-win/issues/112